### PR TITLE
Correct header filtering logic

### DIFF
--- a/src/clients/s3_client.py
+++ b/src/clients/s3_client.py
@@ -1,5 +1,4 @@
 """Client wrapper over aws services."""
-import json
 import re
 import time
 import urllib


### PR DESCRIPTION
*fixes Issue #2*

*Description of changes:*
Corrects the header filtering logic to ensure that `x-amz` headers are correctly included in the call to the presigned URL, if they are part of the signature.

This commit includes a unit test to confirm the correct header filtering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
